### PR TITLE
ADMIN API 추가 및 보강

### DIFF
--- a/cabinet/models.py
+++ b/cabinet/models.py
@@ -3,7 +3,6 @@ from django.db import models
 from user.models import users, buildings
 from enum import Enum
 
-
 class CabinetStatusEnum(Enum):
     BROKEN = 'BROKEN'
     AVAILABLE = 'AVAILABLE'

--- a/cabinet/urls.py
+++ b/cabinet/urls.py
@@ -14,4 +14,6 @@ urlpatterns = [
     path('all', views.CabinetFindAll.as_view(), name='all'),
     path('admin/return', views.CabinetAdminReturnView.as_view(), name='admin_return'),
     path('admin/change/status', views.CabinetAdminChangeStatusView.as_view(), name='admin_change_status'),
+    path('admin/dashboard', views.CabinetDashboardView.as_view(), name='admin_dashboard'),
+    path('status/search', views.CabinetStatusSearchView.as_view(), name='status'),
 ]

--- a/sql/cabinet_cabinets.sql
+++ b/sql/cabinet_cabinets.sql
@@ -1,6 +1,6 @@
 insert into cabinet_cabinets (id, user_id_id, building_id_id, cabinet_number, status, payable, created_at, updated_at, deleted_at) values (1, 2, 1, 1, 'USING', 'FREE', '5/17/2024', '2/24/2024', '8/6/2024');
 insert into cabinet_cabinets (id, user_id_id, building_id_id, cabinet_number, status, payable, created_at, updated_at, deleted_at) values (2, null, 1, 2, 'BROKEN', 'FREE', '11/6/2024', '8/24/2024', '11/21/2023');
-insert into cabinet_cabinets (id, user_id_id, building_id_id, cabinet_number, status, payable, created_at, updated_at, deleted_at) values (3, 4, 1, 3, 'OVERDUE', 'FREE', '8/29/2024', '9/15/2024', '11/7/2024');
+insert into cabinet_cabinets (id, user_id_id, building_id_id, cabinet_number, status, payable, created_at, updated_at, deleted_at) values (3, 4, 1, 3, 'USING', 'FREE', '8/29/2024', '9/15/2024', '11/7/2024');
 insert into cabinet_cabinets (id, user_id_id, building_id_id, cabinet_number, status, payable, created_at, updated_at, deleted_at) values (4, null, 1, 4, 'AVAILABLE', 'FREE', '12/2/2023', '9/17/2024', '11/19/2023');
 insert into cabinet_cabinets (id, user_id_id, building_id_id, cabinet_number, status, payable, created_at, updated_at, deleted_at) values (5, null, 1, 5, 'AVAILABLE', 'FREE', '6/18/2024', '4/29/2024', '4/7/2024');
 insert into cabinet_cabinets (id, user_id_id, building_id_id, cabinet_number, status, payable, created_at, updated_at, deleted_at) values (6, null, 1, 6, 'AVAILABLE', 'FREE', '12/15/2023', '6/11/2024', '6/24/2024');


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#49

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

admin 서비스에서 사용할 다중 id 선택 구현 및
admin 페이지 메인에서 사용할 대시보드 및 고장, 연체 사물함 로그 부분에 따른 상태로 사물함 조회할 수 있는 기능 추가했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
