### PR TITLE
cabinet 조회 api 필드 내용 다른 에러 해결 및 개인 프로필 조회 datetime 에러 해결 

### DIFF
--- a/cabinet/persistence/cabinet_history_repository.py
+++ b/cabinet/persistence/cabinet_history_repository.py
@@ -38,6 +38,7 @@ class CabinetHistoryRepository:
         
     def return_cabinet(self, cabinet : object, user_id : int):
         return cabinet_histories.objects.filter(user_id=user_id, cabinet_id=cabinet, ended_at=None).update(
+            expired_at=timezone.now(),
             ended_at=timezone.now(),
             updated_at=timezone.now()
         )

--- a/cabinet/serializer/CabinetDetailSerializer.py
+++ b/cabinet/serializer/CabinetDetailSerializer.py
@@ -1,5 +1,8 @@
 from rest_framework import serializers
 
+from django.utils import timezone
+import datetime
+
 from cabinet.models import cabinets, cabinet_histories
 
 from authn.models import authns

--- a/user/serializers.py
+++ b/user/serializers.py
@@ -30,15 +30,18 @@ class GetProfileMeSerializer(CamelCaseSerializer):
         except cabinet_histories.DoesNotExist:
             cabinet_history = None
 
-        # Make `current_time` timezone-aware
-        current_time = datetime.now(pytz.UTC)  # Ensure timezone awareness
+        # Make current_time timezone-aware
+        current_time = datetime.now(pytz.UTC)
 
-        # Calculate `leftDate`
-        left_date = (
-            (cabinet_history.expired_at - current_time).days
-            if cabinet_history and cabinet_history.expired_at
-            else None
-        )
+        # Calculate leftDate
+        left_date = None
+        if cabinet_history and cabinet_history.expired_at:
+            # Make expired_at timezone-aware if it isn't already
+            expired_at = cabinet_history.expired_at
+            if expired_at.tzinfo is None:
+                expired_at = pytz.UTC.localize(expired_at)
+            
+            left_date = (expired_at - current_time).days
 
         return {
             'building': cabinet.building_id.name,


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#62 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- cabinet 조회 api들이 (/cabinet, /cabinet/detail) isRentAvailable 필드에 대한 내용이 다른 문제를 해결했습니다.

- user/profile/me 가 datetime으로 인해 비정상적으로 작동하는 문제를 해결했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
